### PR TITLE
fix: delete corresponding course_rate and flush cache while deleting …

### DIFF
--- a/routes/post.js
+++ b/routes/post.js
@@ -291,7 +291,11 @@ router.delete('/:id', function (req, res) {
     var id = req.params.id;
     console.log('\n' + 'DELETE post/' + id);
     db.DeleteById('post', id, function (err) {
-        res.send('Success');
+        db.DeleteByColumn('course_rate', {post_id: id}, function(err){
+            redis.flushdb( function (err, result) {
+                res.send("success");
+            });
+        });
     });
 });
 


### PR DESCRIPTION
While deleting a post, it should also delete the corresponding course_rate record and clean up the data in the Redis cache.
Fixing the issue of the back-end api DELETE /post/:id
